### PR TITLE
fix: Cannot read property 'url_path' of null

### DIFF
--- a/server/content-api/services/prepare-path.js
+++ b/server/content-api/services/prepare-path.js
@@ -24,7 +24,7 @@ module.exports = () => ({
       if (key === 'url_path_id') {
         if (Number(value) && value !== null) {
           const pathEntity = await getPluginService('pathService').findOne(value);
-          data['url_path'] = pathEntity.url_path;
+          data['url_path'] = pathEntity?.url_path;
         }
 
         // delete data.url_path_id;


### PR DESCRIPTION
### What does it do?

In case of broken relations in database (if we have url_path_id but missing corresponding record in url_paths table), we will get error:
```
[2022-11-09 09:51:26.651] error: Cannot read property 'url_path' of null
TypeError: Cannot read property 'url_path' of null
    at /srv/app/node_modules/@strapi-community/strapi-plugin-url-alias/server/content-api/services/prepare-path.js:27:41
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Promise.all (index 6)
    at async Object.traverse [as preparePath] (/srv/app/node_modules/@strapi-community/strapi-plugin-url-alias/server/content-api/services/prepare-path.js:18:5)
    at async Object.response (/srv/app/node_modules/@strapi-community/strapi-plugin-url-alias/server/content-api/services/prepare-path.js:38:12)
    at async Object.findOne (/srv/app/node_modules/@strapi-community/strapi-plugin-url-alias/server/admin-api/services/override-query-layer.js:18:24)
    at async Object.findOneWithCreatorRoles (/srv/app/node_modules/@strapi/plugin-content-manager/server/services/entity-manager.js:160:20)
    at async Object.findOne (/srv/app/node_modules/@strapi/plugin-content-manager/server/controllers/collection-types.js:51:20)
    at async returnBodyMiddleware (/srv/app/node_modules/@strapi/strapi/lib/services/server/compose-endpoint.js:52:18)

```

and because database layer don't have foreign keys for keep data consistent, it's need be validated in code.

### Why is it needed?

-

### How to test it?

-

~~Close: 21~~
Related #21 