### PR TITLE
fix: `url_path_id` will now be unique

### DIFF
--- a/server/admin-api/register.ts
+++ b/server/admin-api/register.ts
@@ -18,6 +18,12 @@ export default async (strapi) => {
       visible: false,
       default: null,
       type: 'string',
+      unique: true,
+      pluginOptions: {
+        i18n: {
+          localized: true,
+        },
+      },
     });
   });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

It makes the `url_path_id`  field unique for the current content type and tells i18n that it should be localized (even though it is default).

### Why is it needed?

The ids should be unique anyway, so this is just an extra protection to avoid wrong data on the different entries.

It helps prevent #33 but it still copies over the data, so we cannot close it

### How to test it?

Follow the steps in #33 and see that you get an error instead

### Related issue(s)/PR(s)

#33