### PR TITLE
fix(PatternField): Popover can now be dismissed

### DIFF
--- a/admin/components/PatternField/index.tsx
+++ b/admin/components/PatternField/index.tsx
@@ -27,6 +27,8 @@ const PatternField: FC<Props> = ({
   const patternRef = useRef<HTMLDivElement>(null);
   const { formatMessage } = useIntl();
 
+  const [popoverDismissed, setPopoverDismissed] = useState(false);
+
   const { data: allowedFields } = useQuery<Record<string, string[]>>(
     ['url-alias', 'pattern', 'allowed-fields'],
     () => request(`/url-alias/pattern/allowed-fields`, { method: "GET" }),
@@ -87,6 +89,7 @@ const PatternField: FC<Props> = ({
           placeholder="/en/pages/[id]"
           error={error}
           onChange={(e: any) => {
+            setPopoverDismissed(false);
             if (e.target.value.match(/^[A-Za-z0-9-_.~[\]/]*$/)) {
               setFieldValue('pattern', e.target.value);
             }
@@ -94,8 +97,8 @@ const PatternField: FC<Props> = ({
         />
       </div>
       {hint(patternHint())}
-      {values.pattern.endsWith('[') && (activeElement as any)?.name === 'pattern' && (
-        <Popover source={patternRef} fullWidth>
+      {values.pattern.endsWith('[') && !popoverDismissed && (
+        <Popover source={patternRef} onDismiss={() => setPopoverDismissed(true)} fullWidth>
           <Stack size={1}>
             {allowedFields[uid].map((fieldName) => (
               <HoverBox


### PR DESCRIPTION
### What does it do?

The pattern field was using a popover, but after updating the design system package it fills the entire screen, making the field unusable. It will now be possible to dismiss the popover.

### How to test it?

Try creating a new pattern and press outside the popover, the popover will now go away.
