### PR TITLE
Enable url alias through sidebar

### DIFF
--- a/admin/components/ContentManagerHooks/ConfirmationCheckbox/index.tsx
+++ b/admin/components/ContentManagerHooks/ConfirmationCheckbox/index.tsx
@@ -1,0 +1,147 @@
+import React, { FC, useState } from "react";
+
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Flex,
+  Typography,
+} from "@strapi/design-system";
+import { ExclamationMarkCircle } from "@strapi/icons";
+import { useIntl } from "react-intl";
+import styled from "styled-components";
+import getTrad from "../../../helpers/getTrad";
+
+const TextAlignTypography = styled(Typography)`
+  text-align: center;
+`;
+
+type Props = {
+  description: {
+    id: string;
+    defaultMessage: string;
+    values: object;
+  },
+  intlLabel: {
+    id: string;
+    defaultMessage: string;
+    values: {
+      [key: string]: any;
+    };
+  },
+  isCreating: boolean,
+  name: string,
+  onChange: (value: any) => void,
+  value: boolean,
+};
+
+const CheckboxConfirmation: FC<Props> = ({
+  description,
+  isCreating,
+  intlLabel,
+  name,
+  onChange,
+  value,
+}) => {
+  const { formatMessage } = useIntl();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleChange = (newValue: boolean) => {
+    if (isCreating || newValue) {
+      return onChange({ target: { name, value: newValue, type: "checkbox" } });
+    }
+
+    if (!newValue) {
+      return setIsOpen(true);
+    }
+
+    return null;
+  };
+
+  const handleConfirm = () => {
+    onChange({ target: { name, value: false, type: "checkbox" } });
+    setIsOpen(false);
+  };
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  const label = intlLabel.id
+    ? formatMessage(
+      { id: intlLabel.id, defaultMessage: intlLabel.defaultMessage },
+      { ...intlLabel.values },
+    )
+    : name;
+
+  const hint = description
+    ? formatMessage(
+      { id: description.id, defaultMessage: description.defaultMessage },
+      { ...description.values },
+    )
+    : "";
+
+  return (
+    <>
+      <Checkbox
+        hint={hint}
+        id={name}
+        name={name}
+        onValueChange={handleChange}
+        value={value}
+        type="checkbox"
+      >
+        {label}
+      </Checkbox>
+      {isOpen && (
+        <Dialog onClose={handleToggle} title="Confirmation" isOpen={isOpen}>
+          <DialogBody icon={<ExclamationMarkCircle />}>
+            <Flex direction="column" alignItems="stretch" gap={2}>
+              <Flex justifyContent="center">
+                <TextAlignTypography id="confirm-description">
+                  {formatMessage({
+                    id: getTrad("url-alias.CheckboxConfirmation.Modal.content"),
+                    defaultMessage:
+                      "Disabling url alias will engender the deletion of all your paths for this content type",
+                  })}
+                </TextAlignTypography>
+              </Flex>
+              <Flex justifyContent="center">
+                <Typography fontWeight="semiBold" id="confirm-description">
+                  {formatMessage({
+                    id: getTrad("CheckboxConfirmation.Modal.body"),
+                    defaultMessage: "Do you want to disable it?",
+                  })}
+                </Typography>
+              </Flex>
+            </Flex>
+          </DialogBody>
+          <DialogFooter
+            startAction={
+              (
+                <Button onClick={handleToggle} variant="tertiary">
+                  {formatMessage({
+                    id: "components.popUpWarning.button.cancel",
+                    defaultMessage: "No, cancel",
+                  })}
+                </Button>
+              )
+            }
+            endAction={
+              (
+                <Button variant="danger-light" onClick={handleConfirm}>
+                  {formatMessage({
+                    id: getTrad("CheckboxConfirmation.Modal.button-confirm"),
+                    defaultMessage: "Yes, disable",
+                  })}
+                </Button>
+              )
+            }
+          />
+        </Dialog>
+      )}
+    </>
+  );
+};
+
+export default CheckboxConfirmation;

--- a/admin/helpers/pluginId.ts
+++ b/admin/helpers/pluginId.ts
@@ -1,4 +1,4 @@
-const pluginPkg = require('../../package.json');
+import pluginPkg from '../../package.json';
 
 const pluginId = pluginPkg.name.replace(
   /^@strapi-community\/strapi-plugin-/i,

--- a/admin/types/app.ts
+++ b/admin/types/app.ts
@@ -1,0 +1,14 @@
+export type App = {
+  registerPlugin: (plugin: {
+    [key: string]: any;
+  }) => void;
+  createSettingSection: (id: any, sections: any[]) => void;
+
+  injectContentManagerComponent: (a: string, b: string, ...args: any[]) => void;
+
+  getPlugin: (name: string) => null | undefined | {
+    [key: string]: any;
+  };
+
+  [key: string]: any;
+};

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@strapi/icons": "^1.8.0",
     "@strapi/strapi": "^4.11.2",
     "@strapi/utils": "^4.11.2",
+    "@types/lodash": "^4.14.195",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
@@ -77,7 +78,8 @@
     "react-query": "^3.39.3",
     "rimraf": "^5.0.1",
     "styled-components": "^5.2.3",
-    "typescript": "~5.0.0"
+    "typescript": "~5.0.0",
+    "yup": "^1.2.0"
   },
   "bugs": {
     "url": "https://github.com/strapi-community/strapi-plugin-url-alias/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,7 +3348,7 @@
     "@types/interpret" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.165", "@types/lodash@^4.14.175":
+"@types/lodash@^4.14.165", "@types/lodash@^4.14.175", "@types/lodash@^4.14.195":
   version "4.14.195"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
   integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
@@ -10645,7 +10645,7 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-property-expr@^2.0.4:
+property-expr@^2.0.4, property-expr@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
   integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
@@ -12406,6 +12406,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-invariant@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
@@ -12564,7 +12569,7 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-type-fest@^2.18.0:
+type-fest@^2.18.0, type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
@@ -13287,3 +13292,13 @@ yup@^0.32.9:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+yup@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
+  integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Creates a checkbox to enable and disable url alias for all content types

### Why is it needed?

Enabling url alias only for specific content types can improve performance and remove clutter. Especially for the end user editing content types that should not have a url.

### How to test it?

TODO

### Related issue(s)/PR(s)

resolves #15