### PR TITLE
feat(enable button): EditView is hidden if url alias is not enabled

### DIFF
--- a/admin/components/EditView/index.tsx
+++ b/admin/components/EditView/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "@strapi/design-system";
 
 import getTrad from "../../helpers/getTrad";
-import { usePluginOptions } from "../../helpers/queries/info";
+import { useUrlAliasContentTypes } from "../../helpers/queries/info";
 
 type Props = {
   /**
@@ -30,8 +30,9 @@ const EditView: FC<Props> = ({ slug }) => {
   const { modifiedData, onChange } = useCMEditViewDataManager();
 
   const hasPath = !!Number(modifiedData.url_path_id);
-  const { data: pluginOptions, isLoading: pluginOptionsLoading } = usePluginOptions(slug);
-  const isEnabled = pluginOptions?.enabled ?? false;
+  // const { data: pluginOptions, isLoading: pluginOptionsLoading } = usePluginOptions(slug);
+  const { data: urlAliasContentTypes, isLoading: contentTypesIsLoading } = useUrlAliasContentTypes();
+  const isEnabled = !urlAliasContentTypes ? false : urlAliasContentTypes.some((contentType) => contentType.uid === slug);
   const { data: pathEntity = {}, isLoading: isQueryLoading } = useQuery(
     ["url-alias", "findOne", modifiedData.url_path_id, modifiedData.updatedAt],
     () => request(`/url-alias/findOne/${modifiedData.url_path_id}`, {
@@ -42,7 +43,7 @@ const EditView: FC<Props> = ({ slug }) => {
     },
   );
 
-  const isLoading = pluginOptionsLoading ? true : !isEnabled ? false : hasPath ? isQueryLoading : false;
+  const isLoading = contentTypesIsLoading ? true : !isEnabled ? false : hasPath ? isQueryLoading : false;
 
   if (!isEnabled) {
     return null;

--- a/admin/helpers/queries/info.ts
+++ b/admin/helpers/queries/info.ts
@@ -1,0 +1,14 @@
+import { request } from "@strapi/helper-plugin";
+import { useQuery } from "react-query";
+import pluginId from "../pluginId";
+import { pluginOptionsSchema } from "../../../lib/schemas/pluginOptions";
+
+export const usePluginOptions = (uid: string) => {
+  return useQuery([pluginId, "pluginOptions", uid], async () => {
+    const response = await request(`/${pluginId}/info/getPluginOptions/${uid}`, {
+      method: "GET",
+    });
+    const parsed = pluginOptionsSchema.cast(response);
+    return parsed;
+  });
+};

--- a/admin/helpers/queries/info.ts
+++ b/admin/helpers/queries/info.ts
@@ -2,13 +2,19 @@ import { request } from "@strapi/helper-plugin";
 import { useQuery } from "react-query";
 import pluginId from "../pluginId";
 import { pluginOptionsSchema } from "../../../lib/schemas/pluginOptions";
+import { getContentTypesSchema } from "../../../lib/schemas/getContentTypes";
 
-export const usePluginOptions = (uid: string) => {
-  return useQuery([pluginId, "pluginOptions", uid], async () => {
-    const response = await request(`/${pluginId}/info/getPluginOptions/${uid}`, {
+export const useUrlAliasContentTypes = () => {
+  return useQuery([pluginId, "contentTypes"], async () => {
+    const response = await request(`/${pluginId}/info/getContentTypes`, {
       method: "GET",
     });
-    const parsed = pluginOptionsSchema.cast(response);
+    const parsed = getContentTypesSchema.validateSync(response);
     return parsed;
+  }, {
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
   });
 };

--- a/admin/helpers/queries/info.ts
+++ b/admin/helpers/queries/info.ts
@@ -12,6 +12,7 @@ export const useUrlAliasContentTypes = () => {
     const parsed = getContentTypesSchema.validateSync(response);
     return parsed;
   }, {
+    // TODO: Should refetch in dev after content type changes
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/admin/screens/Patterns/CreatePage/index.tsx
+++ b/admin/screens/Patterns/CreatePage/index.tsx
@@ -25,25 +25,14 @@ import Center from '../../../components/Center';
 import Select from '../../../components/Select';
 import LabelField from '../../../components/LabelField';
 import PatternField from '../../../components/PatternField';
+import { useUrlAliasContentTypes } from '../../../helpers/queries/info';
 
 const CreatePattternPage = () => {
   const { push } = useHistory();
   const toggleNotification = useNotification();
-  const [loading, setLoading] = useState(false);
-  const [contentTypes, setContentTypes] = useState([]);
   const { formatMessage } = useIntl();
 
-  useEffect(() => {
-    setLoading(true);
-    request(`/url-alias/info/getContentTypes`, { method: 'GET' })
-      .then((res: any) => {
-        setContentTypes(res);
-        setLoading(false);
-      })
-      .catch(() => {
-        setLoading(false);
-      });
-  }, []);
+  const { data: contentTypes = [], isLoading } = useUrlAliasContentTypes();
 
   const handleCreateSubmit = (values: any, { setSubmitting, setErrors }: any) => {
     request(`/url-alias/pattern/create`, {
@@ -88,7 +77,7 @@ const CreatePattternPage = () => {
     return errors;
   };
 
-  if (loading || !contentTypes) {
+  if (isLoading || !contentTypes) {
     return (
       <Center>
         <Loader>{formatMessage({ id: 'url-alias.settings.loading', defaultMessage: "Loading content..." })}</Loader>

--- a/admin/screens/Patterns/EditPage/index.tsx
+++ b/admin/screens/Patterns/EditPage/index.tsx
@@ -25,30 +25,20 @@ import Center from "../../../components/Center";
 import Select from "../../../components/Select";
 import LabelField from "../../../components/LabelField";
 import PatternField from "../../../components/PatternField";
+import { useUrlAliasContentTypes } from '../../../helpers/queries/info';
 
 const EditPatternPage = () => {
   const { push } = useHistory();
   const toggleNotification = useNotification();
   const [loading, setLoading] = useState(false);
   const [patternEntity, setPatternEntity] = useState<null | any>(null);
-  const [contentTypes, setContentTypes] = useState([]);
   const { formatMessage } = useIntl();
 
   const {
     params: { id },
   } = useRouteMatch<{ id: string }>(`/settings/${pluginId}/patterns/:id`)!;
 
-  useEffect(() => {
-    setLoading(true);
-    request(`/url-alias/info/getContentTypes`, { method: "GET" })
-      .then((res: any) => {
-        setContentTypes(res);
-        setLoading(false);
-      })
-      .catch(() => {
-        setLoading(false);
-      });
-  }, []);
+  const { data: contentTypes = [], isLoading } = useUrlAliasContentTypes();
 
   useEffect(() => {
     setLoading(true);
@@ -115,7 +105,7 @@ const EditPatternPage = () => {
     return errors;
   };
 
-  if (loading || !contentTypes || !patternEntity) {
+  if (loading || isLoading || !contentTypes || !patternEntity) {
     return (
       <Center>
         <Loader>

--- a/lib/schemas/getContentTypes.ts
+++ b/lib/schemas/getContentTypes.ts
@@ -1,0 +1,12 @@
+"use strict";
+
+import { object, array, string, InferType } from "yup";
+
+export const getContentTypesSchema = array(
+  object({
+    name: string().required(),
+    uid: string().required(),
+  }),
+).required();
+
+export type GetContentTypes = InferType<typeof getContentTypesSchema>;

--- a/lib/schemas/pluginOptions.ts
+++ b/lib/schemas/pluginOptions.ts
@@ -1,0 +1,9 @@
+"use strict";
+
+import { object, boolean, InferType } from "yup";
+
+export const pluginOptionsSchema = object({
+  enabled: boolean().default(true),
+});
+
+export type PluginOptions = InferType<typeof pluginOptionsSchema>;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "develop": "run-p develop:*",
     "build:server": "tsc -p tsconfig.server.json",
     "build:admin": "tsc -p tsconfig.json",
+    "build:copy": "copyfiles package.json dist/",
     "build": "rimraf dist && run-s build:*"
   },
   "dependencies": {},
@@ -56,6 +57,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "babel-eslint": "9.0.0",
+    "copyfiles": "^2.4.1",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/server/admin-api/controllers/info.ts
+++ b/server/admin-api/controllers/info.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 import _ from "lodash";
+import { getPluginService } from "../../util/getPluginService";
 
 /**
  * Info controller
@@ -62,6 +63,23 @@ export default {
       ctx.status = err.status || 500;
       ctx.body = err.message;
       ctx.app.emit("error", err, ctx);
+    }
+  },
+
+  getPluginOptions: async (ctx) => {
+    const { params } = ctx;
+    const { uid } = params;
+
+    if (typeof uid !== "string") return ctx.badRequest("uid must be a string");
+
+    try {
+      const service = getPluginService("infoService");
+      const pluginOptions = await service.getPluginOptions(uid);
+
+      ctx.send(pluginOptions);
+    } catch (err) {
+      ctx.status = err.status || 500;
+      ctx.body = err.message;
     }
   },
 };

--- a/server/admin-api/controllers/info.ts
+++ b/server/admin-api/controllers/info.ts
@@ -4,6 +4,7 @@ import _ from "lodash";
 import { getPluginService } from "../../util/getPluginService";
 import { PluginOptions } from "../../../lib/schemas/pluginOptions";
 import { GetContentTypes } from '../../../lib/schemas/getContentTypes';
+import { isContentTypeEnabled } from "../../util/enabledContentTypes";
 
 /**
  * Info controller
@@ -16,19 +17,8 @@ export default {
 
       const infoService = getPluginService("infoService");
       await Promise.all(
-        Object.values(strapi.contentTypes).map(async (contentType: any) => {
-          const { pluginOptions } = contentType;
-
-          // Not for CTs that are not visible in the content manager.
-          const isInContentManager = _.get(pluginOptions, [
-            "content-manager",
-            "visible",
-          ]);
-          if (isInContentManager === false) return;
-
-          const urlAliasPluginOptions = infoService.getPluginOptions(contentType.uid) as PluginOptions;
-
-          if (!urlAliasPluginOptions.enabled) {
+        Object.entries(strapi.contentTypes).map(async ([uid, contentType]: any) => {
+          if (!isContentTypeEnabled(uid)) {
             return;
           }
 

--- a/server/admin-api/controllers/pattern.ts
+++ b/server/admin-api/controllers/pattern.ts
@@ -2,6 +2,7 @@
 
 import _ from "lodash";
 import { getPluginService } from "../../util/getPluginService";
+import { isContentTypeEnabled } from "../../util/enabledContentTypes";
 
 /**
  * Pattern controller
@@ -76,14 +77,9 @@ const controller = ({ strapi }) => ({
     const formattedFields = {};
 
     Object.values(strapi.contentTypes).map(async (contentType: any) => {
-      const { pluginOptions } = contentType;
-
-      // Not for CTs that are not visible in the content manager.
-      const isInContentManager = _.get(pluginOptions, [
-        "content-manager",
-        "visible",
-      ]);
-      if (isInContentManager === false) return;
+      if (!isContentTypeEnabled(contentType.uid)) {
+        return;
+      }
 
       const fields = await getPluginService("patternService").getAllowedFields(
         contentType,

--- a/server/admin-api/register.ts
+++ b/server/admin-api/register.ts
@@ -1,15 +1,16 @@
 'use strict';
 
 import _ from 'lodash';
+import { isContentTypeEnabled } from '../util/enabledContentTypes';
 
 export default async (strapi) => {
   // Register the url_path_id field.
   Object.values(strapi.contentTypes).forEach((contentType: any) => {
     const { attributes, pluginOptions } = contentType;
 
-    // Not for CTs that are not visible in the content manager.
-    const isInContentManager = _.get(pluginOptions, ['content-manager', 'visible']);
-    if (isInContentManager === false) return;
+    if (!isContentTypeEnabled(contentType.uid)) {
+      return;
+    }
 
     _.set(attributes, 'url_path_id', {
       writable: true,

--- a/server/admin-api/routes/info.ts
+++ b/server/admin-api/routes/info.ts
@@ -17,4 +17,12 @@ export default [
       policies: [],
     },
   },
+  {
+    method: "GET",
+    path: "/info/getPluginOptions/:uid",
+    handler: "info.getPluginOptions",
+    config: {
+      policies: [],
+    },
+  },
 ];

--- a/server/admin-api/routes/info.ts
+++ b/server/admin-api/routes/info.ts
@@ -17,12 +17,4 @@ export default [
       policies: [],
     },
   },
-  {
-    method: "GET",
-    path: "/info/getPluginOptions/:uid",
-    handler: "info.getPluginOptions",
-    config: {
-      policies: [],
-    },
-  },
 ];

--- a/server/admin-api/services/info.ts
+++ b/server/admin-api/services/info.ts
@@ -1,0 +1,15 @@
+'use strict';
+
+import { get } from 'lodash';
+import { pluginOptionsSchema } from '../../../lib/schemas/pluginOptions';
+import { pluginId } from '../../util/pluginId';
+
+export default () => ({
+  getPluginOptions: (uid: string) => {
+    const contentType = strapi.contentType(uid);
+    const pluginOptions = get(contentType, ['pluginOptions', pluginId], {});
+    const schema = pluginOptionsSchema;
+
+    return schema.cast(pluginOptions);
+  },
+});

--- a/server/admin-api/services/lifecycle.ts
+++ b/server/admin-api/services/lifecycle.ts
@@ -3,6 +3,7 @@
 import _ from "lodash";
 
 import { getPluginService } from "../../util/getPluginService";
+import { isContentTypeEnabled } from "../../util/enabledContentTypes";
 
 /**
  * Update an entity.
@@ -193,14 +194,10 @@ const subscribeLifecycleMethods = async (modelName) => {
 export default () => ({
   async loadAllLifecycleMethods() {
     Object.keys(strapi.contentTypes).map(async (contentType) => {
-      const { pluginOptions } = strapi.contentTypes[contentType];
-
       // Not for CTs that are not visible in the content manager.
-      const isInContentManager = _.get(pluginOptions, [
-        "content-manager",
-        "visible",
-      ]);
-      if (isInContentManager === false) return;
+      if (!isContentTypeEnabled(contentType)) {
+        return;
+      }
 
       await subscribeLifecycleMethods(contentType);
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import adminApiPatternRoutes from "./admin-api/routes/pattern";
 import adminApiInfoRoutes from "./admin-api/routes/info";
 import adminApiLifecycleService from "./admin-api/services/lifecycle";
 import adminApiOverrideQueryLayerService from "./admin-api/services/override-query-layer";
+import adminApiInfoService from "./admin-api/services/info";
 
 // Content API
 import contentApiByPathController from "./content-api/controllers/by-path";
@@ -66,5 +67,6 @@ export default {
     lifecycleService: adminApiLifecycleService,
     byPathService: contentApiByPathService,
     overrideQueryLayer: adminApiOverrideQueryLayerService,
+    infoService: adminApiInfoService,
   },
 };

--- a/server/util/enabledContentTypes.ts
+++ b/server/util/enabledContentTypes.ts
@@ -1,0 +1,18 @@
+import _ from 'lodash';
+import { pluginId } from './pluginId';
+import { pluginOptionsSchema } from '../../lib/schemas/pluginOptions';
+
+export const isContentTypeEnabled = (uid: string) => {
+  const contentType = strapi.contentTypes[uid];
+  const { pluginOptions } = contentType;
+
+  const isInContentManager = _.get(pluginOptions, ['content-manager', 'visible']);
+  if (isInContentManager === false) return false;
+
+  const urlAliasPluginOptionsRaw = _.get(pluginOptions, [pluginId], {});
+  const urlAliasOptions = pluginOptionsSchema.cast(urlAliasPluginOptionsRaw );
+
+  if (!urlAliasOptions.enabled) return false;
+
+  return true;
+};

--- a/strapi-admin.js
+++ b/strapi-admin.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./dist/admin').default;
+module.exports = require('./dist/admin/admin').default;

--- a/strapi-server.js
+++ b/strapi-server.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./dist/server');
+module.exports = require('./dist/server/server');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@strapi/typescript-utils/tsconfigs/admin",
 
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "dist/admin",
     "rootDir": ".",
     "target": "ESNext",
     "noEmit": false,

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "@strapi/typescript-utils/tsconfigs/server",
 
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "dist/server",
     "rootDir": "."
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,7 +5276,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==
 
-copyfiles@2.4.1:
+copyfiles@2.4.1, copyfiles@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.4.1.tgz#d2dcff60aaad1015f09d0b66e7f0f1c5cd3c5da5"
   integrity sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==


### PR DESCRIPTION
### What does it do?

If a content type has disabled url alias it will no longer show the url alias edit view in the content manager

### Why is it needed?

Less clutter on the page, which gives a better user experience

### How to test it?

Try disabling url alias for one of your content types and check in the content manager that it is longer there

### Related issue(s)/PR(s)

#38 