### PR TITLE
fix(preparePath): Will now check if the data is an array and iterate it

### DIFF
--- a/server/content-api/services/prepare-path.ts
+++ b/server/content-api/services/prepare-path.ts
@@ -11,7 +11,12 @@ export default () => ({
    * @param data the data.
    * @returns {object} transformed data
    */
-  preparePath: async function traverse(data: any) {
+  preparePath: async function traverse(data: any): Promise<any> {
+    if (Array.isArray(data)) {
+      await Promise.all(data.map((item) => traverse(item)));
+      return data;
+    }
+
     if (!isObject(data)) {
       return data;
     }
@@ -21,6 +26,7 @@ export default () => ({
         await traverse(data[key]);
         return;
       }
+
 
       if (key === 'url_path_id') {
         if (Number(value) && value !== null) {


### PR DESCRIPTION
### What does it do?

After preparepath was modified it would no longer iterate over arrays, this pull request fixes that

### How to test it?

Try finding many of an entity in the current version and in this version. In this PR it will populate the `url_path`.

