### PR TITLE
fix(lifecycles): create new path if id exists, but no entity

### DIFF
--- a/server/admin-api/services/lifecycle.ts
+++ b/server/admin-api/services/lifecycle.ts
@@ -20,7 +20,13 @@ const updateEntity = async (event, modelName) => {
   const fetchedEntity = await strapi.entityService.findOne(uid, id);
   const entity = _.merge(fetchedEntity, data);
 
-  if (!entity.url_path_id) {
+  // In some cases the entity may have a url_path_id but no path entity.
+  // If there is no path entity we need to create one.
+  const initialPathEntity = await getPluginService("pathService").findOne(
+    entity.url_path_id,
+  );
+
+  if (!entity.url_path_id || !initialPathEntity) {
     let pathEntity;
 
     if (!data.path_generated && data.path_value) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

It checks if the path entity actually exists. If it does not it will create a new one.

### Why is it needed?

In certain cases the database may have wrong data since the `url_path_id` is not a relation.

### Related issues/PRs

Maybe related to #27 but I am not sure
